### PR TITLE
Handling of inner section

### DIFF
--- a/bin/get-reducer-conf.js
+++ b/bin/get-reducer-conf.js
@@ -6,9 +6,13 @@ function getReducerConf(initialValues) {
     const arr = initialValues.targetDocumentList.filter((targetDocument) => {
         return targetDocument.documentPaths.basename !== 'SUMMARY';
     });
-    const faqMetaData = initialValues.targetDocumentList.filter((targetDocument) => {
+    const summaries = initialValues.targetDocumentList.filter((targetDocument) => {
         return targetDocument.documentPaths.basename === 'SUMMARY';
-    })[0].fmMetaData;
+    });
+    if (summaries.length === 0) {
+        throw new Error('SUMMARY.md file not found');
+    }
+    const faqMetaData = summaries[0].fmMetaData;
     const initialValue = [
         model_impl_1.ReducedTargetDocumentImpl.createReducedTargetDocumentImpl(md_file_converter_1.TargetDocument.createTargetDocument({
             documentPaths: initialValues.targetDocumentPaths,

--- a/bin/map-parsed-document.js
+++ b/bin/map-parsed-document.js
@@ -25,7 +25,7 @@ function makeUnConfiguredMapParsedDocument({ marked }) {
                     documentPaths: mdParsedDocumentImpl.documentPaths,
                     transformedData,
                     fmMetaData: mdParsedDocumentImpl.fmMetaData
-                }), mdParsedDocumentImpl.documentPaths.basename, parseWithMarked(mdParsedDocumentImpl.sectionTitleToken));
+                }), parseWithMarked(mdParsedDocumentImpl.sectionTitleToken));
             }
         };
     };

--- a/bin/model-impl/md-target-document-impl.js
+++ b/bin/model-impl/md-target-document-impl.js
@@ -1,18 +1,20 @@
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 class TargetDocumentImpl {
-    static createTargetDocumentImpl(targetDocument, sectionName, sectionTitle) {
-        return new TargetDocumentImpl(targetDocument, sectionName, sectionTitle);
+    static createTargetDocumentImpl(targetDocument, sectionTitle) {
+        return new TargetDocumentImpl(targetDocument, sectionTitle);
     }
-    constructor(targetDocument, sectionName, sectionTitle) {
+    constructor(targetDocument, sectionTitle) {
         this.documentPaths = targetDocument.documentPaths;
         this.transformedData = targetDocument.transformedData;
         this.fmMetaData = targetDocument.fmMetaData || null;
-        this.setSectionName(sectionName);
+        this.setSectionName(targetDocument.documentPaths.src);
         this.sectionTitle = sectionTitle;
     }
-    setSectionName(sectionName) {
-        this.sectionName = 'section-' + sectionName.substring(0, 3);
+    setSectionName(path) {
+        const lastFolderSep = path.lastIndexOf('/');
+        const previousLastFolderSep = path.lastIndexOf('/', lastFolderSep - 1);
+        this.sectionName = path.substring(previousLastFolderSep + 1, lastFolderSep);
     }
     getSectionName() {
         return this.sectionName;

--- a/bin/reduce-target-document-list.js
+++ b/bin/reduce-target-document-list.js
@@ -27,13 +27,15 @@ function initMdDocument(reducedTargetDocumentList, targetDocumentToReduceCurrent
             return sections;
         }
     }, {});
-    reducedTargetDocumentList[0].mdSectionList = Object
-        .entries(sectionListObject)
-        .reduce((md, section) => {
-        const links = section[1].qaList.reduce((qaMd, listItem) => {
+    const orderedSectionNames = Object.keys(sectionListObject).sort().map((key) => {
+        return key;
+    });
+    reducedTargetDocumentList[0].mdSectionList = orderedSectionNames.reduce((md, sectionName) => {
+        const links = sectionListObject[sectionName].qaList.reduce((qaMd, listItem) => {
             return qaMd + listItem;
         }, '');
-        return md + `\n${section[1].sectionTitle}\n${links}`;
+        const level = sectionName.split('-').length - 2;
+        return md + `\n${'#'.repeat(level)}${sectionListObject[sectionName].sectionTitle}\n${links}`;
     }, '');
     return reducedTargetDocumentList;
 }

--- a/src/map-parsed-document.ts
+++ b/src/map-parsed-document.ts
@@ -33,7 +33,6 @@ export function makeUnConfiguredMapParsedDocument({ marked }: any): UnConfigured
                         transformedData,
                         fmMetaData: mdParsedDocumentImpl.fmMetaData
                     }),
-                    mdParsedDocumentImpl.documentPaths.basename,
                     parseWithMarked(mdParsedDocumentImpl.sectionTitleToken)
                 );
             }

--- a/src/model-impl/md-target-document-impl.ts
+++ b/src/model-impl/md-target-document-impl.ts
@@ -3,8 +3,8 @@
 import { IDocumentPaths, ITargetDocument } from 'md-file-converter';
 
 export class TargetDocumentImpl implements ITargetDocument {
-    public static createTargetDocumentImpl(targetDocument: ITargetDocument, sectionName: string, sectionTitle: string): TargetDocumentImpl {
-        return new TargetDocumentImpl(targetDocument, sectionName, sectionTitle);
+    public static createTargetDocumentImpl(targetDocument: ITargetDocument, sectionTitle: string): TargetDocumentImpl {
+        return new TargetDocumentImpl(targetDocument, sectionTitle);
     }
 
     public documentPaths: IDocumentPaths;
@@ -13,16 +13,18 @@ export class TargetDocumentImpl implements ITargetDocument {
     public sectionTitle: string;
     private sectionName: string;
 
-    protected constructor(targetDocument: ITargetDocument, sectionName: string, sectionTitle: string) {
+    protected constructor(targetDocument: ITargetDocument, sectionTitle: string) {
         this.documentPaths = targetDocument.documentPaths;
         this.transformedData = targetDocument.transformedData;
         this.fmMetaData = targetDocument.fmMetaData || null;
-        this.setSectionName(sectionName);
+        this.setSectionName(targetDocument.documentPaths.src);
         this.sectionTitle = sectionTitle;
     }
 
-    public setSectionName(sectionName: string): void {
-        this.sectionName = 'section-' + sectionName.substring(0, 3);
+    public setSectionName(path: string): void {
+        const lastFolderSep = path.lastIndexOf('/');
+        const previousLastFolderSep = path.lastIndexOf('/', lastFolderSep - 1);
+        this.sectionName = path.substring(previousLastFolderSep + 1, lastFolderSep);
     }
 
     public getSectionName(): string {

--- a/src/reduce-target-document-list.ts
+++ b/src/reduce-target-document-list.ts
@@ -40,23 +40,20 @@ function initMdDocument(reducedTargetDocumentList: ReducedTargetDocumentImpl[], 
             }
         }, {});
 
-    // Sort, to have inner section following the parent section
-    const sectionListObjectOrdered: any = {};
-    Object.keys(sectionListObject).sort().forEach((key)  => {
-        sectionListObjectOrdered[key] = sectionListObject[key];
+    // Sortint section to have inner section following the parent section
+    const orderedSectionNames: string[] = Object.keys(sectionListObject).sort().map((key)  => {
+        return key;
     });
 
-    reducedTargetDocumentList[0].mdSectionList = Object
-        .entries(sectionListObjectOrdered)
-        .reduce((md: string, section: any) => {
-            const links = section[1].qaList.reduce((qaMd: string, listItem: string) => {
+    reducedTargetDocumentList[0].mdSectionList = orderedSectionNames.reduce((md: string, sectionName: string) => {
+            const links = sectionListObject[sectionName].qaList.reduce((qaMd: string, listItem: string) => {
                 return qaMd + listItem;
             }, '');
 
             // section[0] contains the name of the section (e.g.: 'section-002-001')
             // We count the number of dash to add title level in the summary (initially the section title has two '#')
-            const level = section[0].split('-').length - 2;
-            return md + `\n${'#'.repeat(level)}${section[1].sectionTitle}\n${links}`;
+            const level = sectionName.split('-').length - 2;
+            return md + `\n${'#'.repeat(level)}${sectionListObject[sectionName].sectionTitle}\n${links}`;
         }, '');
 
     return reducedTargetDocumentList;

--- a/src/reduce-target-document-list.ts
+++ b/src/reduce-target-document-list.ts
@@ -40,8 +40,14 @@ function initMdDocument(reducedTargetDocumentList: ReducedTargetDocumentImpl[], 
             }
         }, {});
 
+    // Sort, to have inner section following the parent section
+    const sectionListObjectOrdered: any = {};
+    Object.keys(sectionListObject).sort().forEach((key)  => {
+        sectionListObjectOrdered[key] = sectionListObject[key];
+    });
+
     reducedTargetDocumentList[0].mdSectionList = Object
-        .entries(sectionListObject)
+        .entries(sectionListObjectOrdered)
         .reduce((md: string, section: any) => {
             const links = section[1].qaList.reduce((qaMd: string, listItem: string) => {
                 return qaMd + listItem;

--- a/src/reduce-target-document-list.ts
+++ b/src/reduce-target-document-list.ts
@@ -47,7 +47,10 @@ function initMdDocument(reducedTargetDocumentList: ReducedTargetDocumentImpl[], 
                 return qaMd + listItem;
             }, '');
 
-            return md + `\n${section[1].sectionTitle}\n${links}`;
+            // section[0] contains the name of the section (e.g.: 'section-002-001')
+            // We count the number of dash to add title level in the summary (initially the section title has two '#')
+            const level = section[0].split('-').length - 2;
+            return md + `\n${'#'.repeat(level)}${section[1].sectionTitle}\n${links}`;
         }, '');
 
     return reducedTargetDocumentList;

--- a/tests/actual-files/faq/section-002-001/002.q001.md
+++ b/tests/actual-files/faq/section-002-001/002.q001.md
@@ -1,0 +1,14 @@
+---
+createDate: 2018-11-19
+lastUpdateDate: 2018-11-20
+author: marco46
+keywords: lnk, raccourci, fichier
+---
+
+# FAQ Git pour developpez.com
+
+## 2.1 Configuration
+
+### Comment définir l'adresse email ?
+
+On va faire un `git config --global user.email "example@example.com"`.

--- a/tests/actual-files/faq/section-002-001/002.q002.md
+++ b/tests/actual-files/faq/section-002-001/002.q002.md
@@ -1,0 +1,14 @@
+---
+createDate: 2018-11-19
+lastUpdateDate: 2018-11-20
+author: marco46
+keywords: lnk, raccourci, fichier
+---
+
+# FAQ Git pour developpez.com
+
+## 2.1 Configuration
+
+### Comment définir le nom de l'utilisateur ?
+
+On va faire un `git config --global user.name "John Doe"`.

--- a/tests/expected-files/SUMMARY.md
+++ b/tests/expected-files/SUMMARY.md
@@ -58,6 +58,11 @@ licence: CC-BY-SA-4.0
 - [Comment installer Git sur macOS ?](section-002/002.q002.md)
 - [Comment installer Git sur Linux ?](section-002/002.q003.md)
 
+### 2.1 Configuration
+
+- [Comment définir l'adresse email ?](section-002-001/002.q001.md)
+- [Comment définir le nom de l'utilisateur ?](section-002-001/002.q002.md)
+
 ## 3 Initialisation d’un dépôt
 
 - [Comment initialiser un dépôt ?](section-003/003.q001.md)


### PR DESCRIPTION
Handles inner sections. This is based on the folder name containing the MD FAQ files.
Here an example of subsection FAQ:
```
├── section-001
│   ├── 001.q001.md
│   ├── 001.q002.md
│   └── 001.q003.md
├── section-002
│   ├── 002.q001.md
│   ├── 002.q002.md
│   └── 002.q003.md
├── section-002-001
│   ├── 002.q001.md
│   └── 002.q002.md
├── section-003
│   ├── 003.q001.md
│   ├── 003.q002.md
│   └── 003.q003.md
├── section-004
│   ├── 004.q001.md
│   ├── 004.q002.md
│   └── 004.q003.md
└── SUMMARY.md
```

Note: this method of finding the hierarchy has been chosen for the implementation ease.
Moreover, after this PR, the FAQ file does not need the section inside the name anymore.